### PR TITLE
Fix Linting CI Job

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Generate Swagger docs
         run: swag init --pd --parseInternal -g cmd/main.go
         working-directory: server
+        continue-on-error: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23
+
+      - name: Install swag CLI
+        run: go install github.com/swaggo/swag/cmd/swag@latest
+
+      - name: Generate Swagger docs
+        run: swag init --pd --parseInternal -g cmd/main.go
+        working-directory: server
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           go-version: 1.23
 
+      - name: Download Dependencies
+        run: go mod download
+        working-directory: server
+
       - name: Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@latest
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,9 +2,11 @@ name: GolangCI-Lint
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "**"
   pull_request:
-    branches: [main]
+    branches:
+      - "**"
 
 jobs:
   lint:

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// nothing! This is just so swag can generate the docs
+}


### PR DESCRIPTION
Linting started to fail after removing the auto generated swagger docs from version control. 

This change adds generation of the swagger docs to the linting CI job (as well as enables the CI job for all branches and pull requests)